### PR TITLE
Add build path for CKAN service

### DIFF
--- a/template/compose-dev/services/ckan/ckan.yaml
+++ b/template/compose-dev/services/ckan/ckan.yaml
@@ -1,7 +1,9 @@
 ---
 services:
   ckan:
-    image: ghcr.io/keitaroinc/ckan:${CKAN_VERSION}
+    build:
+      context: ../
+      dockerfile: Dockerfile
     networks:
       - frontend
       - backend


### PR DESCRIPTION
Changes build path for ckan services so it can be used with dist in ckan-pilot