### PR TITLE
Added restart + sync to ckan and extensions

### DIFF
--- a/template/compose-dev/services/ckan/ckan.yaml
+++ b/template/compose-dev/services/ckan/ckan.yaml
@@ -6,12 +6,14 @@ services:
       dockerfile: Dockerfile
     develop:
       watch:
-        - action: rebuild
+        - action: sync+restart
           path: ../extensions
+          target: /app/extensions
+        - action: sync+restart
+          path: ../src
+          target: /app/src
         - action: rebuild
           path: ../compose-dev
-        - action: rebuild
-          path: ../src
         - action: rebuild
           path: ../Dockerfile
     networks:


### PR DESCRIPTION
*   **Feature/Improvement:** Updated CKAN service's `develop.watch` configuration for improved development feedback.
*   Changed watch actions for `../extensions` and `../src` from `rebuild` to `sync+restart`, along with specifying their respective `target` paths (`/app/extensions`, `/app/src`).
*   This allows for faster iteration and hot-reloading of changes to CKAN source code and extensions without requiring a full Docker image rebuild.
